### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 1.0.0
 
 - Initial version, created by Stagehand

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: version_tracking
 description: Xamarin.Essentials VersionTracking for Flutter. 
-version: 1.0.1
+version: 1.0.2
 homepage: https://www.github.com/jamiewest/version_tracking
 author: Jamie West <jamiewst@gmail.com>
 
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   shared_preferences: ^0.5.3+4
-  package_info: ^0.4.0+5
+  package_info: '>=0.4.0+5 <2.0.0'
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).